### PR TITLE
Fix full control hit areas

### DIFF
--- a/Sources/ActivityMonitor/ContentView.swift
+++ b/Sources/ActivityMonitor/ContentView.swift
@@ -266,6 +266,7 @@ struct ContentView: View {
             }.padding(.horizontal, 15).frame(height: 34).background(
               item == metric ? theme.card : Color.clear, in: RoundedRectangle(cornerRadius: 8)
             ).shadow(color: .black.opacity(item == metric ? 0.07 : 0), radius: 2, y: 1)
+              .contentShape(Rectangle())
           }.buttonStyle(.plain).accessibilityAddTraits(item == metric ? .isSelected : []).help(
             "\(item.rawValue) · ⌘\(Metric.allCases.firstIndex(of:item)!+1)")
         }
@@ -284,6 +285,7 @@ struct ContentView: View {
       ).frame(width: 28, height: 26).background(
         appearance == name ? theme.card : Color.clear, in: RoundedRectangle(cornerRadius: 6)
       ).shadow(color: .black.opacity(appearance == name ? 0.05 : 0), radius: 2, y: 1)
+        .contentShape(Rectangle())
     }.buttonStyle(.plain).help("\(name) appearance").accessibilityLabel("\(name) appearance")
       .accessibilityAddTraits(appearance == name ? .isSelected : [])
   }
@@ -313,6 +315,7 @@ struct ContentView: View {
             ).frame(width: 44, height: 24).background(
               range == value ? theme.card : Color.clear, in: RoundedRectangle(cornerRadius: 5)
             ).shadow(color: .black.opacity(range == value ? 0.06 : 0), radius: 2, y: 1)
+              .contentShape(Rectangle())
           }.buttonStyle(.plain)
         }
       }.padding(3).overlay(RoundedRectangle(cornerRadius: 8).stroke(theme.border, lineWidth: 1))

--- a/Sources/ActivityMonitor/Design.swift
+++ b/Sources/ActivityMonitor/Design.swift
@@ -63,6 +63,7 @@ struct MonitorActionButton: ButtonStyle {
       configuration.isPressed ? theme.hover : danger ? theme.coral.opacity(0.08) : Color.clear,
       in: RoundedRectangle(cornerRadius: 8)
     ).overlay(RoundedRectangle(cornerRadius: 8).stroke(theme.border, lineWidth: 1))
+      .contentShape(Rectangle())
   }
 }
 struct BrandMark: View {

--- a/Sources/ActivityMonitor/ProcessTable.swift
+++ b/Sources/ActivityMonitor/ProcessTable.swift
@@ -236,6 +236,7 @@ struct MonitorProcessTable: View {
       }.font(.system(size: 10, weight: sort == key ? .semibold : .regular)).foregroundStyle(
         sort == key ? theme.text : theme.secondary
       ).frame(maxWidth: .infinity, alignment: alignment).padding(.horizontal, 16)
+        .frame(height: 36).contentShape(Rectangle())
     }.buttonStyle(.plain).help(
       unavailableColumn(key)
         ? "This metric is not exposed by public macOS APIs." : "Sort by \(title)"


### PR DESCRIPTION
Clicking the empty padding in a view tab previously did nothing. Tabs now accept clicks across their full visible bounds. The same correction covers theme selectors, history ranges, inspector actions, and the entire table-header height.

Validation: release build and all 11 tests passed locally. Reproduced on v1.0.0: clicking Memory's upper padding at screenshot coordinate (536,22) left CPU selected. The same coordinate on the rebuilt app selects Memory. CI checks run on Apple silicon and Intel and verify the universal installer.
