### PR TITLE
Polish hover, press and focus feedback

### DIFF
--- a/Sources/ActivityMonitor/ContentView.swift
+++ b/Sources/ActivityMonitor/ContentView.swift
@@ -228,14 +228,11 @@ struct ContentView: View {
             HStack(spacing: 7) {
               Image(systemName: item.icon).font(.system(size: 13)).foregroundStyle(
                 item == metric ? theme.blue : theme.secondary)
-              Text(item.rawValue).font(.system(size: 13, weight: .medium)).foregroundStyle(
-                item == metric ? theme.text : theme.secondary)
-            }.padding(.horizontal, 15).frame(height: 34).background(
-              item == metric ? theme.card : Color.clear, in: RoundedRectangle(cornerRadius: 8)
-            ).shadow(color: .black.opacity(item == metric ? 0.07 : 0), radius: 2, y: 1)
-              .contentShape(Rectangle())
-          }.buttonStyle(.plain).accessibilityAddTraits(item == metric ? .isSelected : []).help(
-            "\(item.rawValue) · ⌘\(Metric.allCases.firstIndex(of:item)!+1)")
+              Text(item.rawValue).font(.system(size: 13, weight: .medium))
+            }.padding(.horizontal, 15).frame(height: 34)
+          }.buttonStyle(MonitorSegmentButton(theme: theme, active: item == metric))
+            .accessibilityAddTraits(item == metric ? .isSelected : []).help(
+              "\(item.rawValue) · ⌘\(Metric.allCases.firstIndex(of:item)!+1)")
         }
       }.padding(4).background(theme.recessed, in: RoundedRectangle(cornerRadius: 11)).overlay(
         RoundedRectangle(cornerRadius: 11).stroke(theme.separator, lineWidth: 1))
@@ -249,11 +246,10 @@ struct ContentView: View {
     } label: {
       Image(systemName: icon).font(.system(size: 13)).foregroundStyle(
         appearance == name ? theme.blue : theme.tertiary
-      ).frame(width: 28, height: 26).background(
-        appearance == name ? theme.card : Color.clear, in: RoundedRectangle(cornerRadius: 6)
-      ).shadow(color: .black.opacity(appearance == name ? 0.05 : 0), radius: 2, y: 1)
-        .contentShape(Rectangle())
-    }.buttonStyle(.plain).help("\(name) appearance").accessibilityLabel("\(name) appearance")
+      ).frame(width: 28, height: 26)
+    }.buttonStyle(MonitorSegmentButton(theme: theme, active: appearance == name, radius: 6)).help(
+      "\(name) appearance"
+    ).accessibilityLabel("\(name) appearance")
       .accessibilityAddTraits(appearance == name ? .isSelected : [])
   }
   var sectionHeading: some View {
@@ -277,13 +273,9 @@ struct ContentView: View {
           Button {
             range = value
           } label: {
-            Text("\(value) min").font(.system(size: 10)).foregroundStyle(
-              range == value ? theme.text : theme.secondary
-            ).frame(width: 44, height: 24).background(
-              range == value ? theme.card : Color.clear, in: RoundedRectangle(cornerRadius: 5)
-            ).shadow(color: .black.opacity(range == value ? 0.06 : 0), radius: 2, y: 1)
-              .contentShape(Rectangle())
-          }.buttonStyle(.plain)
+            Text("\(value) min").font(.system(size: 10)).frame(width: 44, height: 24)
+          }.buttonStyle(MonitorSegmentButton(theme: theme, active: range == value, radius: 5))
+            .accessibilityAddTraits(range == value ? .isSelected : [])
         }
       }.padding(3).overlay(RoundedRectangle(cornerRadius: 8).stroke(theme.border, lineWidth: 1))
     }

--- a/Sources/ActivityMonitor/Design.swift
+++ b/Sources/ActivityMonitor/Design.swift
@@ -41,29 +41,76 @@ struct DesignCard<Content: View>: View {
     ).shadow(color: .black.opacity(theme.dark ? 0.06 : 0.025), radius: 2, y: 1)
   }
 }
+private enum ControlSurfaceKind { case segment, icon, action, danger }
+
+private struct ControlSurface: ViewModifier {
+  let theme: MonitorTheme
+  let kind: ControlSurfaceKind
+  var active = false
+  var pressed = false
+  var radius: CGFloat = 8
+  @Environment(\.isEnabled) private var enabled
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @State private var hovering = false
+  private var highlighted: Bool { enabled && (hovering || pressed) }
+  private var foreground: Color {
+    if kind == .danger { return highlighted ? .white : theme.coral }
+    return kind == .action || active || highlighted ? theme.text : theme.secondary
+  }
+  private var background: Color {
+    switch kind {
+    case .danger: return highlighted ? theme.coral : theme.coral.opacity(0.08)
+    case .icon: return active || highlighted ? theme.recessed : .clear
+    case .action: return highlighted ? theme.hover : .clear
+    case .segment:
+      return pressed && enabled
+        ? theme.recessed : active ? theme.card : highlighted ? theme.hover : .clear
+    }
+  }
+  func body(content: Content) -> some View {
+    content.foregroundStyle(foreground)
+      .background(background, in: RoundedRectangle(cornerRadius: radius))
+      .overlay {
+        if kind == .action {
+          RoundedRectangle(cornerRadius: radius).stroke(theme.border, lineWidth: 1)
+        }
+      }
+      .shadow(color: .black.opacity(kind == .segment && active ? 0.06 : 0), radius: 2, y: 1)
+      .contentShape(Rectangle()).opacity(enabled ? 1 : 0.4)
+      .onHover { hovering = enabled && $0 }
+      .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: hovering)
+  }
+}
+
+struct MonitorSegmentButton: ButtonStyle {
+  let theme: MonitorTheme
+  var active = false
+  var radius: CGFloat = 8
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label.modifier(
+      ControlSurface(
+        theme: theme, kind: .segment, active: active,
+        pressed: configuration.isPressed, radius: radius))
+  }
+}
 struct MonitorIconButton: ButtonStyle {
   let theme: MonitorTheme
   var active = false
   func makeBody(configuration: Configuration) -> some View {
-    configuration.label.font(.system(size: 14, weight: .regular)).foregroundStyle(
-      active ? theme.text : theme.secondary
-    ).frame(width: 32, height: 32).background(
-      active || configuration.isPressed ? theme.recessed : Color.clear,
-      in: RoundedRectangle(cornerRadius: 8)
-    ).contentShape(Rectangle())
+    configuration.label.font(.system(size: 14)).frame(width: 32, height: 32)
+      .modifier(
+        ControlSurface(theme: theme, kind: .icon, active: active, pressed: configuration.isPressed))
   }
 }
 struct MonitorActionButton: ButtonStyle {
   let theme: MonitorTheme
   var danger = false
   func makeBody(configuration: Configuration) -> some View {
-    configuration.label.font(.system(size: 11, weight: .medium)).foregroundStyle(
-      danger ? theme.coral : theme.text
-    ).frame(maxWidth: .infinity).frame(height: 33).background(
-      configuration.isPressed ? theme.hover : danger ? theme.coral.opacity(0.08) : Color.clear,
-      in: RoundedRectangle(cornerRadius: 8)
-    ).overlay(RoundedRectangle(cornerRadius: 8).stroke(theme.border, lineWidth: 1))
-      .contentShape(Rectangle())
+    configuration.label.font(.system(size: 11, weight: .medium))
+      .frame(maxWidth: .infinity).frame(height: 33)
+      .modifier(
+        ControlSurface(
+          theme: theme, kind: danger ? .danger : .action, pressed: configuration.isPressed))
   }
 }
 struct BrandMark: View {

--- a/Sources/ActivityMonitor/Gallery.swift
+++ b/Sources/ActivityMonitor/Gallery.swift
@@ -4,6 +4,7 @@ struct DesignGallery: View {
   @EnvironmentObject var monitor: Monitor
   let select: (Metric, String) -> Void
   let close: () -> Void
+  @State private var previewRows: [ProcessRow] = []
   var body: some View {
     VStack(spacing: 0) {
       HStack {
@@ -33,6 +34,9 @@ struct DesignGallery: View {
         }.padding(28)
       }
     }.frame(width: 1080, height: 760)
+      .onReceive(monitor.$rows) { rows in
+        previewRows = Array(rows.sorted { $0.cpu > $1.cpu }.prefix(3))
+      }
   }
   func preview(_ metric: Metric, _ dark: Bool) -> some View {
     let theme = MonitorTheme(dark: dark)
@@ -54,7 +58,7 @@ struct DesignGallery: View {
             width: 460, height: 78, alignment: .topLeading)
           VStack(spacing: 0) {
             ForEach(
-              Array(monitor.rows.sorted { $0.cpu > $1.cpu }.prefix(3).enumerated()),
+              Array(previewRows.enumerated()),
               id: \.element.id
             ) { index, p in
               HStack {
@@ -67,16 +71,29 @@ struct DesignGallery: View {
             }
           }.clipShape(RoundedRectangle(cornerRadius: 5))
         }.padding(14).background(theme.window)
-        HStack {
-          Label(
-            metric.rawValue + " / " + (dark ? "Dark" : "Light"),
-            systemImage: dark ? "moon" : "sun.max")
-          Spacer()
-          Image(systemName: "arrow.right")
-        }.font(.system(size: 11)).foregroundStyle(theme.secondary).padding(12).background(
-          theme.card)
+        GalleryFooter(metric: metric, dark: dark, theme: theme)
+
       }.foregroundStyle(theme.text).clipShape(RoundedRectangle(cornerRadius: 12)).overlay(
         RoundedRectangle(cornerRadius: 12).stroke(theme.border, lineWidth: 1))
     }.buttonStyle(.plain)
+  }
+}
+
+private struct GalleryFooter: View {
+  let metric: Metric
+  let dark: Bool
+  let theme: MonitorTheme
+  @State private var hovering = false
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  var body: some View {
+    HStack {
+      Label(
+        metric.rawValue + " / " + (dark ? "Dark" : "Light"), systemImage: dark ? "moon" : "sun.max")
+      Spacer()
+      Image(systemName: "arrow.right")
+    }.font(.system(size: 11)).foregroundStyle(theme.secondary).padding(12)
+      .background(hovering ? theme.hover : theme.card)
+      .onHover { hovering = $0 }
+      .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: hovering)
   }
 }

--- a/Sources/ActivityMonitor/Overview.swift
+++ b/Sources/ActivityMonitor/Overview.swift
@@ -172,7 +172,7 @@ struct MonitorOverview: View {
             theme.tertiary)
         }
         HStack {
-          mini(monitor.rows.reduce(0) { $0 + Int($1.threads) }.formatted(), "Threads available")
+          mini(monitor.rows.reduce(0) { $0 + Int($1.threads) }.formatted(), "Threads")
           mini(monitor.rows.count.formatted(), "Processes")
         }
         HStack {

--- a/Sources/ActivityMonitor/ProcessTable.swift
+++ b/Sources/ActivityMonitor/ProcessTable.swift
@@ -172,7 +172,10 @@ struct MonitorProcessTable: View {
         }
       }.padding(.horizontal, 10).frame(width: 230, height: 31).background(
         theme.subtle, in: RoundedRectangle(cornerRadius: 7)
-      ).overlay(RoundedRectangle(cornerRadius: 7).stroke(theme.border, lineWidth: 1)).padding(
+      ).overlay(
+        RoundedRectangle(cornerRadius: 7).stroke(
+          searchFocus.wrappedValue ? theme.blue.opacity(0.65) : theme.border, lineWidth: 1)
+      ).padding(
         .leading, 8)
       Rectangle().fill(theme.border).frame(width: 1, height: 18).padding(.horizontal, 3)
       Button {
@@ -243,7 +246,7 @@ struct MonitorProcessTable: View {
         sort == key ? theme.text : theme.secondary
       ).frame(maxWidth: .infinity, alignment: alignment).padding(.horizontal, 16)
         .frame(height: 36).contentShape(Rectangle())
-    }.buttonStyle(.plain).help(
+    }.buttonStyle(MonitorSegmentButton(theme: theme, radius: 0)).help(
       unavailableColumn(key)
         ? "This metric is not exposed by public macOS APIs." : "Sort by \(title)"
     ).disabled(unavailableColumn(key))
@@ -300,7 +303,7 @@ private struct ProcessTableRow: View, Equatable {
         if isSelected { Rectangle().fill(theme.blue).frame(width: 2) }
       }.overlay(alignment: .bottom) { Rectangle().fill(theme.separator).frame(height: 1) }
         .contentShape(Rectangle())
-    }.buttonStyle(.plain).focusEffectDisabled().onHover { hovered = $0 }
+    }.buttonStyle(.plain).focusEffectDisabled().onHover { hovered = $0 }.help(row.name)
       .simultaneousGesture(TapGesture(count: 2).onEnded { inspect(row) }).contextMenu {
         Button("Inspect") { inspect(row) }
         Button("Copy PID") {
@@ -331,7 +334,8 @@ private struct ProcessTableRow: View, Equatable {
           )
           .foregroundColor(color)
         let resolved = context.resolve(label)
-        let textSize = resolved.measure(in: CGSize(width: CGFloat.greatestFiniteMagnitude, height: 41))
+        let textSize = resolved.measure(
+          in: CGSize(width: CGFloat.greatestFiniteMagnitude, height: 41))
         var cellContext = context
         cellContext.clip(
           to: Path(CGRect(x: x + 10, y: 0, width: max(0, cellWidth - 20), height: 41)))


### PR DESCRIPTION
Add the original mockup's hover and press surfaces to tabs, theme/range selectors, toolbar controls, table headers and inspector actions. Hover transitions honor Reduce Motion; disabled controls remain inactive. Search now shows a focus border, selected history ranges expose their selected state, and process names have tooltips.

The gallery footer also responds to hover, and its shared preview process list is sorted once per snapshot instead of separately in all ten previews. These interaction states stay local to controls instead of invalidating the dashboard.

Release build passed. Native visual/interaction checks and CI follow before merge. Original design: https://chatgpt.com/share/6a9c6a89-70e0-83eb-a977-4ca6e6f34766
