### PR TITLE
Add secure Apple signing and notarization in Actions

### DIFF
--- a/.github/RELEASE_NOTES.md
+++ b/.github/RELEASE_NOTES.md
@@ -13,6 +13,5 @@ Activity Monitor 1.1 improves everyday navigation and process-table performance.
 
 Download the **universal DMG**, open it, and drag **Activity Monitor** to **Applications**. The **universal ZIP** contains the complete `.app` bundle as an alternative. Both support Apple silicon and Intel on macOS 14 or later. `SHA256SUMS` verifies download contents; `INSTALL.md` contains installation details.
 
-This release is **ad-hoc signed, not Apple notarized**. After trying to open a downloaded copy, macOS may require **System Settings → Privacy & Security → Open Anyway**. Only proceed if you trust this source. No administrator helper is installed.
 
 Metrics use live macOS data. Protected counters, Apple's proprietary Energy Impact, GPU accounting and per-process packet counts are explicitly unavailable. See the repository README for measurement semantics.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,8 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Toolchain
         run: swift --version && xcodebuild -version
+      - name: Packaging failure-gate tests
+        run: python3 -m unittest discover -s Tests/Packaging -v
       - name: Build and test
         run: swift test
   package:
@@ -46,4 +48,4 @@ jobs:
             dist/*.dmg
             dist/*.zip
             dist/SHA256SUMS
-            INSTALL.md
+            dist/INSTALL.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,9 @@ jobs:
           VERSION: ${{ needs.version.outputs.version }}
           EXPECT_NOTARIZED: '1'
         run: ./scripts/verify-package.sh
+      - name: Remove signing credentials
+        if: ${{ always() }}
+        run: ./scripts/cleanup-apple-signing.sh
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ActivityMonitor-notarized
@@ -85,9 +88,6 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
           path: dist/*notary*.json
-      - name: Remove signing credentials
-        if: ${{ always() }}
-        run: ./scripts/cleanup-apple-signing.sh
   publish:
     needs: [version, build, sign]
     if: >-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,76 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       version: ${{ needs.version.outputs.version }}
-  publish:
+  sign:
+    name: Developer ID signing and notarization
+    if: ${{ vars.APPLE_SIGNING_ENABLED == 'true' }}
     needs: [version, build]
+    runs-on: macos-latest
+    environment: apple-signing
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Require a release commit from main
+        run: git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: ActivityMonitor-universal
+          path: dist
+      - name: Verify the tested app before loading credentials
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          ditto -x -k "dist/ActivityMonitor-$VERSION-universal.zip" dist
+          ./scripts/verify-package.sh
+      - name: Import signing credentials into a temporary keychain
+        env:
+          DEVELOPER_ID_P12_BASE64: ${{ secrets.DEVELOPER_ID_P12_BASE64 }}
+          DEVELOPER_ID_P12_PASSWORD: ${{ secrets.DEVELOPER_ID_P12_PASSWORD }}
+          DEVELOPER_ID_IDENTITY: ${{ secrets.DEVELOPER_ID_IDENTITY }}
+          APP_STORE_CONNECT_KEY_P8: ${{ secrets.APP_STORE_CONNECT_KEY_P8 }}
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+        run: ./scripts/setup-apple-signing.sh
+      - name: Sign and notarize the tested app
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+          USE_PREBUILT_APP: '1'
+        run: ./scripts/package.sh
+      - name: Verify notarization and Gatekeeper acceptance
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+          EXPECT_NOTARIZED: '1'
+        run: ./scripts/verify-package.sh
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ActivityMonitor-notarized
+          if-no-files-found: error
+          retention-days: 30
+          path: |
+            dist/*.dmg
+            dist/*.zip
+            dist/SHA256SUMS
+            dist/INSTALL.md
+      - name: Preserve notarization diagnostics on failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: notarization-diagnostics
+          if-no-files-found: ignore
+          retention-days: 7
+          path: dist/*notary*.json
+      - name: Remove signing credentials
+        if: ${{ always() }}
+        run: ./scripts/cleanup-apple-signing.sh
+  publish:
+    needs: [version, build, sign]
+    if: >-
+      ${{ !cancelled() && needs.version.result == 'success' && needs.build.result == 'success' &&
+          (needs.sign.result == 'success' ||
+           (needs.sign.result == 'skipped' && vars.APPLE_SIGNING_ENABLED != 'true')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -33,8 +101,8 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          name: ActivityMonitor-universal
-          path: release
+          name: ${{ needs.sign.result == 'success' && 'ActivityMonitor-notarized' || 'ActivityMonitor-universal' }}
+          path: release/dist
       - name: Check downloaded artifacts
         working-directory: release/dist
         run: sha256sum -c SHA256SUMS
@@ -42,9 +110,18 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
+          NOTARIZED: ${{ needs.sign.result == 'success' }}
         run: |
-          if ! gh release view "$TAG" >/dev/null 2>&1; then
-            gh release create "$TAG" --verify-tag --draft --title "Activity Monitor ${TAG#v}" --notes-file .github/RELEASE_NOTES.md
+          cp .github/RELEASE_NOTES.md "$RUNNER_TEMP/release-notes.md"
+          if [[ "$NOTARIZED" == true ]]; then
+            printf '\nThis release is **Developer ID-signed and Apple notarized**. Both the DMG and the app inside the ZIP include notarization tickets.\n' >> "$RUNNER_TEMP/release-notes.md"
+          else
+            printf '\nThis release is **ad-hoc signed, not Apple notarized**. See INSTALL.md for first-launch instructions.\n' >> "$RUNNER_TEMP/release-notes.md"
           fi
-          gh release upload "$TAG" release/dist/*.dmg release/dist/*.zip release/dist/SHA256SUMS release/INSTALL.md --clobber
-          gh release edit "$TAG" --draft=false
+          if RELEASE_DRAFT="$(gh release view "$TAG" --json isDraft --jq .isDraft 2>/dev/null)"; then
+            [[ "$RELEASE_DRAFT" == true ]] || { echo 'This version is already published; use a new version tag.' >&2; exit 1; }
+          else
+            gh release create "$TAG" --verify-tag --draft --title "Activity Monitor ${TAG#v}" --notes-file "$RUNNER_TEMP/release-notes.md"
+          fi
+          gh release upload "$TAG" release/dist/*.dmg release/dist/*.zip release/dist/SHA256SUMS release/dist/INSTALL.md --clobber
+          gh release edit "$TAG" --notes-file "$RUNNER_TEMP/release-notes.md" --draft=false

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 dist/
 .DS_Store
 .swiftpm/
+__pycache__/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -21,7 +21,7 @@ NOTARY_PROFILE="your-existing-notary-profile" \
 ./scripts/package.sh
 ```
 
-The optional path signs with hardened runtime, submits the DMG and staples its ticket. It requires your own Apple credentials; none are stored in this repository. The ZIP is an alternative archive of the signed app; the script's stapled artifact is the DMG.
+The optional path signs with hardened runtime and a secure timestamp, notarizes and staples the app, then builds the final ZIP and DMG. It signs, notarizes and staples the DMG too. Both downloads contain the stapled app. Set `EXPECT_NOTARIZED=1` when running `scripts/verify-package.sh` to check tickets and Gatekeeper acceptance. Credentials are never stored in this repository.
 
 ## Structure
 
@@ -43,4 +43,4 @@ GitHub Actions builds and runs the test suite on the latest macOS Apple silicon 
 
 To release, first wait for green CI on the intended commit, then push a version tag such as `v1.0.1`. The release workflow validates the tag, repeats both architecture tests, builds versioned installers, verifies their contents and signatures, and publishes a GitHub release only after all checks succeed. It attaches the DMG, ZIP containing the full app bundle, portable SHA-256 checksums and installation notes. Failed builds do not publish a release.
 
-Hosted builds use ad-hoc signing without credentials. Developer ID/notarization remains available through the local packaging script. Release publication needs only the workflow's scoped GitHub token; pull-request builds have read-only repository permissions.
+Pull-request builds use ad-hoc signing without Apple credentials. Tagged releases can use the protected `apple-signing` environment for Developer ID signing and notarization; see [Apple signing setup](docs/APPLE_SIGNING.md). Once enabled, signing, notarization or Gatekeeper failures prevent publication. The publishing job uses only its scoped GitHub token.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,8 +1,8 @@
-Activity Monitor 1.0 — macOS 14 or later, Apple silicon and Intel
+Activity Monitor — macOS 14 or later, Apple silicon and Intel
 
 Open the disk image and drag Activity Monitor into Applications. Open your installed copy from Applications. This app is separate from Apple's built-in Activity Monitor.
 
-This local build is ad-hoc signed, not Apple notarized. macOS may block a copy downloaded from the internet. After attempting to open it, use System Settings → Privacy & Security → Open Anyway only if you trust the source. No administrator helper is installed, and no security setting needs to be disabled.
+Check the signing status provided with your download. Developer ID-signed and notarized releases can be opened normally. macOS may block an ad-hoc-signed copy downloaded from the internet. After attempting to open it, use System Settings → Privacy & Security → Open Anyway only if you trust the source. No administrator helper is installed, and no security setting needs to be disabled.
 
 To uninstall, quit the app and move it from Applications to the Trash.
 

--- a/Tests/Packaging/test_notarize.py
+++ b/Tests/Packaging/test_notarize.py
@@ -1,0 +1,75 @@
+"""Exercise notarization failure gates without Apple credentials or network access."""
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class NotarizationTests(unittest.TestCase):
+    def run_submission(self, status="Accepted", exit_code="0", profile=True):
+        with tempfile.TemporaryDirectory() as directory:
+            temporary = Path(directory)
+            tool = temporary / "xcrun"
+            tool.write_text('''#!/usr/bin/env python3
+import json, os, sys
+if sys.argv[2] == "submit":
+    assert "--wait" in sys.argv and "--timeout" in sys.argv
+    assert "--keychain-profile" in sys.argv and "--keychain" in sys.argv
+    status = os.environ["TEST_NOTARY_STATUS"]
+    if status == "Malformed":
+        print("not json")
+    else:
+        print(json.dumps({"id": "test-submission", "status": status}))
+    sys.exit(int(os.environ["TEST_NOTARY_EXIT"]))
+elif sys.argv[2] == "log":
+    open(sys.argv[-1], "w").write('{"issues": ["test failure"]}')
+else:
+    sys.exit(99)
+''')
+            tool.chmod(0o700)
+            archive = temporary / "app.zip"
+            archive.touch()
+            report = temporary / "submission.json"
+            environment = dict(os.environ, PATH=str(temporary) + os.pathsep + os.environ["PATH"],
+                               NOTARY_KEYCHAIN=str(temporary / "test.keychain"),
+                               TEST_NOTARY_STATUS=status, TEST_NOTARY_EXIT=exit_code)
+            environment.pop("NOTARY_PROFILE", None)
+            if profile:
+                environment["NOTARY_PROFILE"] = "test-profile"
+            result = subprocess.run(["/bin/bash", str(ROOT / "scripts/notarize.sh"),
+                                     str(archive), str(report)], env=environment,
+                                    capture_output=True, text=True)
+            return result, Path(str(report) + ".log.json").exists()
+
+    def test_accepted_submission_succeeds(self):
+        result, log = self.run_submission()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(log)
+
+    def test_invalid_submission_fails_and_fetches_log(self):
+        result, log = self.run_submission("Invalid")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertTrue(log)
+
+    def test_in_progress_is_not_success(self):
+        result, _ = self.run_submission("In Progress")
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_timeout_exit_fails_even_with_status_text(self):
+        result, _ = self.run_submission("Accepted", "1")
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_malformed_response_fails(self):
+        result, _ = self.run_submission("Malformed")
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_missing_credentials_fail(self):
+        result, _ = self.run_submission(profile=False)
+        self.assertNotEqual(result.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/APPLE_SIGNING.md
+++ b/docs/APPLE_SIGNING.md
@@ -1,0 +1,69 @@
+# Apple signing in GitHub Actions
+
+Tagged releases can use your Apple Developer Program membership to distribute a Developer ID-signed and notarized app outside the Mac App Store. Ordinary CI and pull requests remain ad-hoc signed and receive no Apple credentials.
+
+## One-time Apple setup
+
+1. Use an active, paid Apple Developer Program membership. In Xcode → Settings → Accounts → Manage Certificates, create a **Developer ID Application** certificate if you do not already have one. You need the appropriate account permissions; contact your team’s Account Holder if creation is unavailable. An Apple Development or Mac App Distribution certificate is not interchangeable with Developer ID Application.
+2. Export that certificate **with its private key** as a password-protected `.p12` using Keychain Access. The public `.cer` file alone cannot sign an app. Record the full identity, for example `Developer ID Application: Your Name (ABCDE12345)`.
+3. Create an App Store Connect **team API key** authorized for notarization. Download its `.p8` private key, and record the Key ID and Issuer ID. This workflow uses team keys, so the Issuer ID is required. Keep the downloaded key securely; Apple only offers the private-key download once.
+
+For this app’s current capabilities, no App Store listing, sandbox entitlement or provisioning profile is needed. You do not need to put your normal Apple account password in GitHub.
+
+## GitHub configuration
+
+Create a repository environment named **`apple-signing`** under Settings → Environments. Restrict its deployment tags to `v*`, and add a required reviewer to inspect the tagged commit before credentials are released. On a team, prevent self-review so a different trusted person approves. Restrict who can create or update release tags using a repository ruleset. A `v*` name alone does not make a commit trustworthy; review workflow and packaging-script changes in particular.
+
+Add these **environment secrets**, never source files or chat messages. Base64 only encodes the certificate; GitHub secret storage and environment access controls protect it. Keep a secure local backup, and revoke/replace credentials if they are exposed:
+
+| Secret | Value |
+| --- | --- |
+| `DEVELOPER_ID_P12_BASE64` | Base64-encoded `.p12`, including the signing private key |
+| `DEVELOPER_ID_P12_PASSWORD` | Password used to protect the exported `.p12` |
+| `DEVELOPER_ID_IDENTITY` | Full `Developer ID Application: … (TEAMID)` identity |
+| `APP_STORE_CONNECT_KEY_P8` | Contents of the downloaded `.p8` file |
+| `APP_STORE_CONNECT_KEY_ID` | API Key ID |
+| `APP_STORE_CONNECT_ISSUER_ID` | Team API Issuer ID |
+
+For example, upload files directly without printing their contents:
+
+```sh
+base64 -i /secure/path/DeveloperID.p12 | gh secret set DEVELOPER_ID_P12_BASE64 --env apple-signing
+gh secret set APP_STORE_CONNECT_KEY_P8 --env apple-signing < /secure/path/AuthKey_KEYID.p8
+# These commands prompt for values without putting them in shell history:
+gh secret set DEVELOPER_ID_P12_PASSWORD --env apple-signing
+gh secret set DEVELOPER_ID_IDENTITY --env apple-signing
+gh secret set APP_STORE_CONNECT_KEY_ID --env apple-signing
+gh secret set APP_STORE_CONNECT_ISSUER_ID --env apple-signing
+```
+
+After all six secrets are configured, set the **repository Actions variable** `APPLE_SIGNING_ENABLED` to `true`:
+
+```sh
+gh variable set APPLE_SIGNING_ENABLED --body true
+```
+
+This must be a repository variable, not an environment variable: the workflow decides whether to schedule the signing job before entering the environment. Leave it unset until credentials are ready. Once enabled, missing credentials, rejected notarization, timeout, or failed Gatekeeper checks prevent publication; there is no automatic ad-hoc fallback.
+
+## Release behavior
+
+Push a new version tag after merging and verifying the release changes. Existing published versions are not silently re-signed or replaced.
+
+The workflow:
+
+1. Runs Apple silicon and Intel tests and the standard package checks.
+2. Enters the protected environment on a fresh macOS runner, verifies the tagged commit belongs to main, and downloads/verifies the already-tested app. Project compilation runs before credential access.
+3. Imports the certificate into a temporary keychain and validates the notarization credentials.
+4. Signs the universal app with hardened runtime and a secure timestamp.
+5. Submits an app ZIP with `notarytool`, requires `Accepted`, and staples the app.
+6. Creates the final ZIP from that stapled app, then creates, signs, notarizes and staples the DMG.
+7. Validates tickets and Gatekeeper acceptance for the original app, the ZIP-extracted app, the DMG-mounted app and the DMG. Checksums are generated after stapling.
+8. Publishes the notarized artifacts and accurate signing status in installation/release notes, and removes credentials from the signing runner using an always-run cleanup step. Only the separate publication job has `contents: write`; the signing job has `contents: read`.
+
+The ZIP itself cannot be stapled; the app inside it carries the ticket. Notarization submissions wait up to 30 minutes each. On timeout or rejection the release stops. Available diagnostic JSON is retained as a workflow artifact for seven days. A timeout does not mean Apple rejected the app; inspect the submission before retrying the failed job.
+
+## Validation status
+
+The ad-hoc path can be exercised without an Apple account. Script tests check accepted, rejected, timed-out and malformed notarization responses, and missing configuration. They do not establish that a real certificate or Apple account works. The first signed release still requires a successful live Apple submission and Gatekeeper verification with your credentials.
+
+References: [GitHub environment protections](https://docs.github.com/en/actions/reference/workflows-and-actions/deployments-and-environments), [GitHub secure workflow guidance](https://docs.github.com/en/actions/reference/security/secure-use), [Apple Developer ID](https://developer.apple.com/developer-id/), [Apple notarization workflow](https://developer.apple.com/documentation/security/customizing-the-notarization-workflow), [GitHub certificate setup](https://docs.github.com/en/actions/how-tos/deploy/deploy-to-third-party-platforms/sign-xcode-applications).

--- a/docs/APPLE_SIGNING.md
+++ b/docs/APPLE_SIGNING.md
@@ -6,7 +6,7 @@ Tagged releases can use your Apple Developer Program membership to distribute a 
 
 1. Use an active, paid Apple Developer Program membership. In Xcode → Settings → Accounts → Manage Certificates, create a **Developer ID Application** certificate if you do not already have one. You need the appropriate account permissions; contact your team’s Account Holder if creation is unavailable. An Apple Development or Mac App Distribution certificate is not interchangeable with Developer ID Application.
 2. Export that certificate **with its private key** as a password-protected `.p12` using Keychain Access. The public `.cer` file alone cannot sign an app. Record the full identity, for example `Developer ID Application: Your Name (ABCDE12345)`.
-3. Create an App Store Connect **team API key** authorized for notarization. Download its `.p8` private key, and record the Key ID and Issuer ID. This workflow uses team keys, so the Issuer ID is required. Keep the downloaded key securely; Apple only offers the private-key download once.
+3. Create a dedicated App Store Connect **team API key** authorized for notarization, using the lowest role Apple permits for that purpose. Avoid reusing a broader production administration key. Download its `.p8` private key, and record the Key ID and Issuer ID. This workflow uses team keys, so the Issuer ID is required. Keep the downloaded key securely; Apple only offers the private-key download once.
 
 For this app’s current capabilities, no App Store listing, sandbox entitlement or provisioning profile is needed. You do not need to put your normal Apple account password in GitHub.
 

--- a/scripts/cleanup-apple-signing.sh
+++ b/scripts/cleanup-apple-signing.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+set +x
+: "${RUNNER_TEMP:?GitHub runner temporary directory is required}"
+trap 'rm -f "$RUNNER_TEMP/activity-monitor-certificate.p12" "$RUNNER_TEMP/activity-monitor-notary.p8"' EXIT
+KEYCHAIN_PATH="$RUNNER_TEMP/activity-monitor-signing.keychain-db"
+if [[ -f "$KEYCHAIN_PATH" ]]; then
+  security delete-keychain "$KEYCHAIN_PATH"
+fi

--- a/scripts/notarize.sh
+++ b/scripts/notarize.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+: "${NOTARY_PROFILE:?A notarytool keychain profile is required}"
+ARTIFACT="${1:?Pass the archive or disk image to notarize}"
+ARGS=(--keychain-profile "$NOTARY_PROFILE")
+if [[ -n "${NOTARY_KEYCHAIN:-}" ]]; then ARGS+=(--keychain "$NOTARY_KEYCHAIN"); fi
+REPORT="${2:-$ARTIFACT.notary.json}"
+xcrun notarytool submit "$ARTIFACT" "${ARGS[@]}" --wait --timeout 30m --output-format json > "$REPORT"
+STATUS="$(plutil -extract status raw -o - "$REPORT")"
+if [[ "$STATUS" != Accepted ]]; then
+  SUBMISSION="$(plutil -extract id raw -o - "$REPORT")"
+  xcrun notarytool log "$SUBMISSION" "${ARGS[@]}" "$REPORT.log.json" || true
+  echo "Notarization was not accepted ($STATUS). See $REPORT and the adjacent log." >&2
+  exit 1
+fi

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -3,8 +3,13 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 VERSION="${VERSION:-1.1.0}"
 [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "Expected numeric MAJOR.MINOR.PATCH version" >&2; exit 1; }
+if [[ -n "${NOTARY_PROFILE:-}" && "${SIGNING_IDENTITY:-}" != 'Developer ID Application:'* ]]; then
+ echo 'Notarization requires a Developer ID Application signing identity.' >&2
+ exit 1
+fi
 APP="dist/Activity Monitor.app"
 mkdir -p dist
+if [[ "${USE_PREBUILT_APP:-0}" != 1 ]]; then
 swift build -c release --arch arm64 --arch x86_64
 BIN="$(swift build -c release --arch arm64 --arch x86_64 --show-bin-path)/ActivityMonitor"
 mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
@@ -27,21 +32,48 @@ cat > "$APP/Contents/Info.plist" <<PLIST
 </dict></plist>
 PLIST
 swift scripts/icon.swift "$APP/Contents/Resources"
+else
+ # Signing jobs consume the verified build artifact; no project compilation runs with credentials.
+ [[ "$(/usr/libexec/PlistBuddy -c 'Print CFBundleShortVersionString' "$APP/Contents/Info.plist")" == "$VERSION" ]]
+ [[ "$(/usr/libexec/PlistBuddy -c 'Print CFBundleVersion' "$APP/Contents/Info.plist")" == "$VERSION" ]]
+ lipo "$APP/Contents/MacOS/ActivityMonitor" -verify_arch arm64 x86_64
+ codesign --verify --deep --strict "$APP"
+fi
 if [[ -n "${SIGNING_IDENTITY:-}" ]]; then
- codesign --force --options runtime --timestamp --sign "$SIGNING_IDENTITY" "$APP"
+ SIGNING_ARGS=(--force --timestamp)
+ if [[ -n "${SIGNING_KEYCHAIN:-}" ]]; then SIGNING_ARGS+=(--keychain "$SIGNING_KEYCHAIN"); fi
+ codesign --options runtime "${SIGNING_ARGS[@]}" --sign "$SIGNING_IDENTITY" "$APP"
 else
  codesign --force --sign - "$APP"
 fi
 codesign --verify --deep --strict "$APP"
 STAGE="$(mktemp -d)"
 trap 'rm -rf "$STAGE"' EXIT
+if [[ -n "${NOTARY_PROFILE:-}" ]]; then
+ # Staple the app before building either distribution container.
+ ditto -c -k --sequesterRsrc --keepParent "$APP" "$STAGE/notary-app.zip"
+ ./scripts/notarize.sh "$STAGE/notary-app.zip" dist/notary-app.json
+ xcrun stapler staple "$APP"
+ xcrun stapler validate "$APP"
+ SIGNING_STATUS='Developer ID-signed and Apple notarized.'
+elif [[ -n "${SIGNING_IDENTITY:-}" ]]; then
+ SIGNING_STATUS='Signed, but not Apple notarized.'
+else
+ SIGNING_STATUS='Ad-hoc signed, not Apple notarized.'
+fi
+printf 'Activity Monitor %s\nSigning: %s\n\n' "$VERSION" "$SIGNING_STATUS" > dist/INSTALL.md
+cat INSTALL.md >> dist/INSTALL.md
+# Keep notarization submissions outside the DMG staging directory.
+rm -f "$STAGE/notary-app.zip"
 cp -R "$APP" "$STAGE/"
 ln -s /Applications "$STAGE/Applications"
-cp INSTALL.md "$STAGE/Read Me.txt"
+cp dist/INSTALL.md "$STAGE/Read Me.txt"
 hdiutil create -volname "Activity Monitor" -srcfolder "$STAGE" -ov -format UDZO "dist/ActivityMonitor-$VERSION-universal.dmg"
 ditto -c -k --sequesterRsrc --keepParent "$APP" "dist/ActivityMonitor-$VERSION-universal.zip"
 if [[ -n "${NOTARY_PROFILE:-}" ]]; then
- xcrun notarytool submit "dist/ActivityMonitor-$VERSION-universal.dmg" --keychain-profile "$NOTARY_PROFILE" --wait
+ codesign "${SIGNING_ARGS[@]}" --sign "$SIGNING_IDENTITY" "dist/ActivityMonitor-$VERSION-universal.dmg"
+ ./scripts/notarize.sh "dist/ActivityMonitor-$VERSION-universal.dmg"
  xcrun stapler staple "dist/ActivityMonitor-$VERSION-universal.dmg"
+ xcrun stapler validate "dist/ActivityMonitor-$VERSION-universal.dmg"
 fi
 (cd dist && shasum -a 256 "ActivityMonitor-$VERSION-universal.dmg" "ActivityMonitor-$VERSION-universal.zip" > SHA256SUMS)

--- a/scripts/setup-apple-signing.sh
+++ b/scripts/setup-apple-signing.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+set +x
+umask 077
+: "${RUNNER_TEMP:?GitHub runner temporary directory is required}"
+: "${GITHUB_ENV:?GitHub environment file is required}"
+: "${DEVELOPER_ID_P12_BASE64:?Missing Developer ID certificate}"
+: "${DEVELOPER_ID_P12_PASSWORD:?Missing certificate password}"
+: "${DEVELOPER_ID_IDENTITY:?Missing Developer ID identity}"
+: "${APP_STORE_CONNECT_KEY_P8:?Missing notarization API private key}"
+: "${APP_STORE_CONNECT_KEY_ID:?Missing notarization API key ID}"
+: "${APP_STORE_CONNECT_ISSUER_ID:?Missing notarization API issuer ID}"
+[[ "$DEVELOPER_ID_IDENTITY" == 'Developer ID Application:'* ]] || { echo 'Expected a Developer ID Application identity' >&2; exit 1; }
+[[ "$DEVELOPER_ID_IDENTITY" != *$'\n'* && "$DEVELOPER_ID_IDENTITY" != *$'\r'* ]] || exit 1
+KEYCHAIN_PATH="$RUNNER_TEMP/activity-monitor-signing.keychain-db"
+CERTIFICATE_PATH="$RUNNER_TEMP/activity-monitor-certificate.p12"
+API_KEY_PATH="$RUNNER_TEMP/activity-monitor-notary.p8"
+KEYCHAIN_PASSWORD="$(openssl rand -hex 32)"
+echo "::add-mask::$KEYCHAIN_PASSWORD"
+printf '%s' "$DEVELOPER_ID_P12_BASE64" | base64 --decode > "$CERTIFICATE_PATH"
+printf '%s' "$APP_STORE_CONNECT_KEY_P8" > "$API_KEY_PATH"
+security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+security set-keychain-settings -lut 7200 "$KEYCHAIN_PATH"
+security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+security import "$CERTIFICATE_PATH" -P "$DEVELOPER_ID_P12_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security -f pkcs12 -k "$KEYCHAIN_PATH"
+security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" >/dev/null
+xcrun notarytool store-credentials activity-monitor-ci --keychain "$KEYCHAIN_PATH" \
+  --key "$API_KEY_PATH" --key-id "$APP_STORE_CONNECT_KEY_ID" --issuer "$APP_STORE_CONNECT_ISSUER_ID"
+rm -f "$CERTIFICATE_PATH" "$API_KEY_PATH"
+{
+  echo "SIGNING_IDENTITY=$DEVELOPER_ID_IDENTITY"
+  echo "SIGNING_KEYCHAIN=$KEYCHAIN_PATH"
+  echo 'NOTARY_PROFILE=activity-monitor-ci'
+  echo "NOTARY_KEYCHAIN=$KEYCHAIN_PATH"
+} >> "$GITHUB_ENV"

--- a/scripts/verify-package.sh
+++ b/scripts/verify-package.sh
@@ -20,10 +20,18 @@ cleanup() {
 trap cleanup EXIT
 hdiutil attach "dist/ActivityMonitor-$VERSION-universal.dmg" -readonly -nobrowse -mountpoint "$MOUNT"
 [[ "$(readlink "$MOUNT/Applications")" == /Applications ]]
-cmp INSTALL.md "$MOUNT/Read Me.txt"
+cmp dist/INSTALL.md "$MOUNT/Read Me.txt"
 codesign --verify --deep --strict "$MOUNT/Activity Monitor.app"
 cmp "$APP/Contents/MacOS/ActivityMonitor" "$MOUNT/Activity Monitor.app/Contents/MacOS/ActivityMonitor"
 ditto -x -k "dist/ActivityMonitor-$VERSION-universal.zip" "$STAGE/zip"
 codesign --verify --deep --strict "$STAGE/zip/Activity Monitor.app"
 cmp "$APP/Contents/MacOS/ActivityMonitor" "$STAGE/zip/Activity Monitor.app/Contents/MacOS/ActivityMonitor"
+if [[ "${EXPECT_NOTARIZED:-0}" == 1 ]]; then
+  for SIGNED_APP in "$APP" "$MOUNT/Activity Monitor.app" "$STAGE/zip/Activity Monitor.app"; do
+    xcrun stapler validate "$SIGNED_APP"
+    spctl --assess --type execute --verbose=2 "$SIGNED_APP"
+  done
+  xcrun stapler validate "dist/ActivityMonitor-$VERSION-universal.dmg"
+  spctl --assess --type open --context context:primary-signature --verbose=2 "dist/ActivityMonitor-$VERSION-universal.dmg"
+fi
 echo 'Universal app, DMG, ZIP, version and checksums verified.'


### PR DESCRIPTION
Add opt-in Developer ID signing and Apple notarization for tagged releases through the protected `apple-signing` environment. Compilation and normal tests run without Apple credentials; the signing job verifies and signs the already-built universal app. It has read-only repository permissions, and only the separate publishing job can write releases.

The app is notarized and stapled before generating the final ZIP and DMG. The DMG is also signed, notarized and stapled. Gatekeeper/ticket verification must succeed before publication. Missing credentials, rejection and timeout fail closed when signing is enabled. Temporary credentials are cleaned up with an always-run step, and published versions cannot be overwritten by rerunning publication.

[Setup instructions and secret names](https://github.com/wieslawsoltes/ActivityMonitor/blob/main/docs/APPLE_SIGNING.md) explain environment reviewers, tag restrictions, direct secret upload and the repository activation variable. Signing remains disabled until configuration is complete; no Apple credentials have been accessed or uploaded by this PR.

Validation: six notarization response/failure tests pass; shell syntax and actionlint pass (the installed linter's outdated macos-26-intel label warning is excluded). Both normal and prebuilt ad-hoc packaging passed real universal app, DMG, ZIP, version and checksum verification. CI repeats tests and package verification. A live Developer ID/notarization submission cannot be validated until the user's credentials are configured.
