### PR TITLE
Fill remaining workspace height with the process list

### DIFF
--- a/.github/RELEASE_NOTES.md
+++ b/.github/RELEASE_NOTES.md
@@ -1,15 +1,13 @@
-Activity Monitor 1.3.2 gives the process list more room in smaller windows.
+Activity Monitor 1.3.3 fixes unused space below the process list in narrow windows.
 
-### Improved
+### Fixed
 
-- Shorter charts and tighter summary panels across CPU, Memory, Energy, Disk, Network, and GPU.
-- The medium-width overview uses 134 fewer vertical points while keeping both detail panels visible.
-- Compact headings and process controls bring the list into view sooner. Narrow windows retain expandable breakdown and device details.
-- Short windows and the menu-bar monitor use the same compact telemetry presentation. Default and expanded workspaces retain their larger charts.
-- History ranges, chart inspection, GPU selection, and process actions remain available in both appearances.
+- The process list now fills all remaining space down to the status bar.
+- List height adjusts to the actual overview height when resizing or expanding and collapsing device details.
+- Short windows retain a usable minimum list height with scrolling to reach all content.
 
 ### Install
 
 Download the **universal DMG**, open it, and drag **Activity Monitor** to **Applications**. A complete app **ZIP** is also available. Supports Apple silicon and Intel on **macOS 14 or later**. `SHA256SUMS` verifies the downloads; `INSTALL.md` contains installation details.
 
-[Changes since 1.3.1](https://github.com/wieslawsoltes/ActivityMonitor/compare/v1.3.1...v1.3.2)
+[Changes since 1.3.2](https://github.com/wieslawsoltes/ActivityMonitor/compare/v1.3.2...v1.3.3)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       version:
         type: string
-        default: '1.3.2'
+        default: '1.3.3'
 permissions:
   contents: read
 jobs:

--- a/Sources/ActivityMonitor/AdaptiveLayout.swift
+++ b/Sources/ActivityMonitor/AdaptiveLayout.swift
@@ -15,6 +15,52 @@ struct MonitorLayout: Equatable {
   var inlineInspector: Bool { width >= 1120 && height >= 700 }
 }
 
+/// Measures the overview at its natural height, then gives the process list the rest of
+/// the viewport. A minimum list height keeps short windows usable through outer scrolling.
+struct WorkspaceLayout: Layout {
+  let viewportHeight: CGFloat
+  var minimumListHeight: CGFloat = 340
+
+  static func frames(
+    width: CGFloat, viewportHeight: CGFloat, overviewHeights: [CGFloat],
+    minimumListHeight: CGFloat = 340
+  ) -> [CGRect] {
+    var y: CGFloat = 0
+    var frames = overviewHeights.map { height in
+      let frame = CGRect(x: 0, y: y, width: width, height: height)
+      y += height
+      return frame
+    }
+    frames.append(
+      CGRect(
+        x: 0, y: y, width: width, height: max(minimumListHeight, viewportHeight - y)))
+    return frames
+  }
+
+  private func frames(width: CGFloat, subviews: Subviews) -> [CGRect] {
+    Self.frames(
+      width: width, viewportHeight: viewportHeight,
+      overviewHeights: subviews.dropLast().map {
+        $0.sizeThatFits(ProposedViewSize(width: width, height: nil)).height
+      }, minimumListHeight: minimumListHeight)
+  }
+
+  func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+    let width = proposal.width ?? 420
+    return CGSize(width: width, height: frames(width: width, subviews: subviews).last?.maxY ?? 0)
+  }
+
+  func placeSubviews(
+    in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()
+  ) {
+    for (view, frame) in zip(subviews, frames(width: bounds.width, subviews: subviews)) {
+      view.place(
+        at: CGPoint(x: bounds.minX + frame.minX, y: bounds.minY + frame.minY),
+        anchor: .topLeading, proposal: ProposedViewSize(frame.size))
+    }
+  }
+}
+
 /// A three-panel layout shared by every metric. Its geometry is also independently testable.
 struct OverviewGrid: Layout {
   var expanded = false

--- a/Sources/ActivityMonitor/ContentView.swift
+++ b/Sources/ActivityMonitor/ContentView.swift
@@ -70,11 +70,13 @@ struct ContentView: View {
       VStack(spacing: 0) {
         adaptiveTitlebar(layout)
         if layout.scrollsWorkspace {
-          ScrollView {
-            workspace(layout, scrolling: true)
+          GeometryReader { viewport in
+            ScrollView {
+              workspace(layout, viewportHeight: viewport.size.height)
+            }
           }
         } else {
-          workspace(layout, scrolling: false)
+          workspace(layout)
         }
         if layout.standard {
           statusbar
@@ -199,8 +201,12 @@ struct ContentView: View {
         }.hidden()
       }
   }
-  @ViewBuilder func workspace(_ layout: MonitorLayout, scrolling: Bool) -> some View {
-    VStack(spacing: 0) {
+  @ViewBuilder func workspace(_ layout: MonitorLayout, viewportHeight: CGFloat? = nil) -> some View
+  {
+    let container =
+      viewportHeight.map { AnyLayout(WorkspaceLayout(viewportHeight: $0)) }
+      ?? AnyLayout(VStackLayout(spacing: 0))
+    container {
       if !layout.denseOverview {
         sectionHeading.padding(.top, 23).padding(.bottom, 20)
       } else {
@@ -232,8 +238,7 @@ struct ContentView: View {
         if inspector && layout.inlineInspector {
           inspectorPanel.frame(width: layout.inspectorWidth)
         }
-      }.frame(height: scrolling ? max(340, layout.height - 430) : nil)
-        .frame(maxHeight: scrolling ? nil : .infinity)
+      }.frame(maxHeight: .infinity)
     }.padding(.horizontal, layout.gutter)
   }
   var inspectorPanel: some View {

--- a/Tests/ActivityMonitorTests/AdaptiveLayoutTests.swift
+++ b/Tests/ActivityMonitorTests/AdaptiveLayoutTests.swift
@@ -50,6 +50,38 @@ final class AdaptiveLayoutTests: XCTestCase {
     XCTAssertFalse(MonitorLayout(width: 1440, height: 900).denseOverview)
     XCTAssertEqual(OverviewGrid.frames(width: 1748, expanded: true)[2].maxY, 280)
   }
+  func testProcessListFillsRemainingViewportAcrossResizeAndOverviewChanges() {
+    // Includes collapsed details, two-row summaries, and expanded disclosure content.
+    for viewport in [CGFloat(638), 778, 1100, 1600] {
+      for overview in [CGFloat(184), 316, 498] {
+        let frames = WorkspaceLayout.frames(
+          width: 492, viewportHeight: viewport, overviewHeights: [42, overview])
+        let list = frames.last!
+        XCTAssertEqual(list.minY, 42 + overview)
+        XCTAssertGreaterThanOrEqual(list.height, 340)
+        XCTAssertEqual(list.maxY, max(viewport, list.minY + 340))
+        XCTAssertEqual(frames[0].maxY, frames[1].minY)
+        XCTAssertEqual(frames[1].maxY, list.minY)
+      }
+    }
+    let collapsed = WorkspaceLayout.frames(
+      width: 492, viewportHeight: 1000, overviewHeights: [42, 184]
+    ).last!
+    let expanded = WorkspaceLayout.frames(
+      width: 492, viewportHeight: 1000, overviewHeights: [42, 498]
+    ).last!
+    XCTAssertEqual(collapsed.maxY, expanded.maxY)
+    XCTAssertEqual(collapsed.height - expanded.height, 498 - 184)
+  }
+
+  func testShortWorkspaceScrollsInsteadOfCrushingProcessList() {
+    let list = WorkspaceLayout.frames(
+      width: 392, viewportHeight: 358, overviewHeights: [42, 498]
+    ).last!
+    XCTAssertEqual(list.height, 340)
+    XCTAssertGreaterThan(list.maxY, 358)
+  }
+
   func testPriorityColumnsRetainSortAndRespectAvailableColumns() {
     let columns = ["primary", "gpuTime", "cpu", "memory", "pid", "user"].map {
       ProcessColumn(id: $0, title: $0, weight: 1)

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 cd "$(dirname "$0")/.."
-VERSION="${VERSION:-1.3.2}"
+VERSION="${VERSION:-1.3.3}"
 [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "Expected numeric MAJOR.MINOR.PATCH version" >&2; exit 1; }
 if [[ -n "${NOTARY_PROFILE:-}" && "${SIGNING_IDENTITY:-}" != 'Developer ID Application:'* ]]; then
  echo 'Notarization requires a Developer ID Application signing identity.' >&2

--- a/scripts/verify-package.sh
+++ b/scripts/verify-package.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 cd "$(dirname "$0")/.."
-VERSION="${VERSION:-1.3.2}"
+VERSION="${VERSION:-1.3.3}"
 APP='dist/Activity Monitor.app'
 for ARCH in arm64 x86_64; do
   lipo "$APP/Contents/MacOS/ActivityMonitor" -verify_arch "$ARCH"


### PR DESCRIPTION
Narrow windows left a blank strip below the process list because its height still subtracted a fixed 430 points from the whole window. The workspace now measures the heading and overview, then allocates all remaining viewport height to the list. Expanded details and short windows retain a 340-point minimum list with outer scrolling.

Validation: all 40 Swift tests and 6 packaging tests pass locally. Native UI checks cover narrow light/dark windows, expanded details, scrolling at minimum size, and the default workspace. Includes version 1.3.3 release metadata.
