### PR TITLE
Fit process diagnostic tables to the window with compact default columns

### DIFF
--- a/.github/RELEASE_NOTES.md
+++ b/.github/RELEASE_NOTES.md
@@ -1,18 +1,12 @@
-Activity Monitor 1.6.0 adds a complete process diagnostics workspace, individual CPU charts and memory mapping visualizations.
-
-### New
-
-- Inspect each process in a dedicated workspace with six activity histories, detailed counters, threads, files, connections, Mach ports, fileports, memory maps, mapped images and on-demand reports.
-- Detach diagnostics into a floating tool window or pin a process to the menu bar. Retained sessions preserve histories and collected reports.
-- Show individual logical processors, including performance and efficiency core counts where available, or enable per-process thread CPU histories.
-- Fit all CPU charts to the viewport or use optional pagination. Chart mode, filters and pagination survive adaptive layout and metric changes.
-- Compare memory by protection, inspect virtual address ranges with gaps preserved, and rank mapped images by resident or virtual size. Repeated executable mappings are counted correctly.
+Activity Monitor 1.6.1 makes process diagnostic tables easier to read in compact windows.
 
 ### Improved
 
-- Total CPU load, usage breakdown and charts use 100% per logical processor, matching process-list units. Sixteen logical processors have a 1600% combined chart maximum.
-- All fifteen diagnostics pages share the main monitor’s light and dark appearance, with resizable/reorderable tables, filtering, selection and exports.
-- CPU grids balance rows and adapt their height to processor count and available space.
+- Threads, open files, connections, memory maps, mapped images, Mach ports and fileports show a focused set of columns by default.
+- Default columns fit the available window width, with more space for names, paths and endpoints.
+- Right-click a header to show additional fields, fit columns to the window or restore the default layout.
+- Custom column widths and ordering are retained. Wider custom layouts still support horizontal scrolling with both scrollbars attached to the viewport.
+- Numeric values align to the right, empty values display a dash, and tooltips reveal complete text. Filtering and CSV exports include hidden fields.
 
 ### Install
 
@@ -20,8 +14,4 @@ Download the universal DMG or app ZIP for Apple silicon and Intel on macOS 14 or
 
 [Process diagnostics guide](https://github.com/wieslawsoltes/ActivityMonitor/blob/main/docs/diagnostics/README.md) · [Installation guide](https://github.com/wieslawsoltes/ActivityMonitor#installation)
 
-### Availability
-
-Protected process counters remain unavailable where macOS denies access. Shared-cache libraries may not appear individually in mapped images. Native Intel hardware was not used for local validation; forcing the Intel binary under Rosetta can under-report process CPU time.
-
-[Changes since 1.5.0](https://github.com/wieslawsoltes/ActivityMonitor/compare/v1.5.0...v1.6.0)
+[Changes since 1.6.0](https://github.com/wieslawsoltes/ActivityMonitor/compare/v1.6.0...v1.6.1)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       version:
         type: string
-        default: '1.6.0'
+        default: '1.6.1'
 permissions:
   contents: read
 jobs:

--- a/Sources/ActivityMonitor/DiagnosticTable.swift
+++ b/Sources/ActivityMonitor/DiagnosticTable.swift
@@ -11,7 +11,7 @@ struct DiagnosticTable: NSViewRepresentable {
   var persistColumns = true
   func makeCoordinator() -> Coordinator { Coordinator() }
   func makeNSView(context: Context) -> NSScrollView {
-    let scroll = NSScrollView()
+    let scroll = DiagnosticScrollView()
     scroll.hasVerticalScroller = true
     scroll.hasHorizontalScroller = true
     scroll.autohidesScrollers = true
@@ -40,6 +40,7 @@ struct DiagnosticTable: NSViewRepresentable {
     }
     table.menu = menu
     context.coordinator.table = table
+    scroll.fitColumns = { [weak coordinator = context.coordinator] in coordinator?.fitColumns() }
     scroll.documentView = table
     updateNSView(scroll, context: context)
     return scroll
@@ -52,24 +53,42 @@ struct DiagnosticTable: NSViewRepresentable {
     if c.key != key || c.columns != section.columns {
       c.key = key
       c.columns = section.columns
+      c.adjustingColumns = true
+      c.persistColumns = persistColumns
+      c.automaticSizing = true
       table.autosaveTableColumns = false
       for column in table.tableColumns { table.removeTableColumn(column) }
       for title in section.columns {
         let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier(title))
         column.title = title
-        column.minWidth = 55
+        column.minWidth = DiagnosticColumnLayout.minimum(title)
         column.maxWidth = 2400
         column.width =
           ["Path", "Local endpoint", "Remote endpoint", "Name"].contains(title)
           ? 280 : max(90, CGFloat(title.count) * 7 + 26)
+        column.headerCell.alignment = DiagnosticColumnLayout.numeric(title) ? .right : .left
         column.resizingMask = .userResizingMask
         column.sortDescriptorPrototype = NSSortDescriptor(key: title, ascending: true)
         table.addTableColumn(column)
       }
+      let initialWidths = Dictionary(
+        uniqueKeysWithValues: table.tableColumns.map { ($0.title, $0.width) })
       if persistColumns {
         table.autosaveName = "ProcessDiagnostics.\(key).v1"
         table.autosaveTableColumns = true
       }
+      // Preserve an existing customized native layout. Untouched legacy layouts
+      // migrate to the compact defaults instead of restoring every metadata column.
+      let customized =
+        table.tableColumns.map { $0.title } != section.columns
+        || table.tableColumns.contains { column in
+          return column.isHidden
+            || abs(column.width - (initialWidths[column.title] ?? column.width)) > 1
+        }
+      let savedMode =
+        persistColumns ? UserDefaults.standard.object(forKey: c.sizingKey) as? Bool : nil
+      c.automaticSizing = savedMode ?? !customized
+      if savedMode == nil && !customized { c.applyDefaults() }
       let menu = NSMenu()
       for column in table.tableColumns {
         let item = NSMenuItem(
@@ -79,7 +98,19 @@ struct DiagnosticTable: NSViewRepresentable {
         item.state = column.isHidden ? .off : .on
         menu.addItem(item)
       }
+      menu.addItem(.separator())
+      for (title, action) in [
+        ("Fit columns to window", #selector(Coordinator.fitToWindow)),
+        ("Restore default columns", #selector(Coordinator.restoreDefaults)),
+      ] {
+        let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
+        item.target = c
+        menu.addItem(item)
+      }
       table.headerView?.menu = menu
+      c.adjustingColumns = false
+      c.fitColumns()
+      c.saveSizing()
       c.date = nil
     }
     table.appearance = NSAppearance(named: theme.dark ? .darkAqua : .aqua)
@@ -106,6 +137,64 @@ struct DiagnosticTable: NSViewRepresentable {
     var key = "", columns: [String] = [], source: [DiagnosticRecord] = [],
       rows: [DiagnosticRecord] = []
     var query = "", date: Date?
+    var adjustingColumns = false, automaticSizing = true, persistColumns = true
+    var sizingKey: String { "ProcessDiagnostics.\(key).automaticSizing" }
+    func saveSizing() {
+      if persistColumns { UserDefaults.standard.set(automaticSizing, forKey: sizingKey) }
+    }
+    func applyDefaults() {
+      guard let table else { return }
+      let defaults = DiagnosticColumnLayout.defaults(key)
+      for column in table.tableColumns {
+        column.isHidden = defaults.map { !$0.contains(column.title) } ?? false
+      }
+      // Unknown or partial schemas must always leave at least one column visible.
+      if table.tableColumns.allSatisfy(\.isHidden) { table.tableColumns.first?.isHidden = false }
+    }
+    @objc func restoreDefaults() {
+      guard let table else { return }
+      adjustingColumns = true
+      for (index, title) in columns.enumerated() {
+        let current = table.column(withIdentifier: NSUserInterfaceItemIdentifier(title))
+        if current >= 0 && current != index { table.moveColumn(current, toColumn: index) }
+      }
+      applyDefaults()
+      adjustingColumns = false
+      fitToWindow()
+    }
+    @objc func fitToWindow() {
+      automaticSizing = true
+      saveSizing()
+      fitColumns()
+    }
+    func fitColumns() {
+      guard automaticSizing, !adjustingColumns, let table,
+        let scroll = table.enclosingScrollView, scroll.contentSize.width > 0
+      else { return }
+      adjustingColumns = true
+      defer { adjustingColumns = false }
+      let visible = table.tableColumns.filter { !$0.isHidden }
+      let available = max(
+        0, scroll.contentSize.width - CGFloat(visible.count) * table.intercellSpacing.width)
+      let minima = visible.map { DiagnosticColumnLayout.minimum($0.title) }
+      let surplus = max(0, available - minima.reduce(0, +))
+      let weights = visible.map { DiagnosticColumnLayout.flexible($0.title) ? 5.0 : 1.0 }
+      let totalWeight = max(1, weights.reduce(0, +))
+      for index in visible.indices {
+        visible[index].width = minima[index] + surplus * weights[index] / totalWeight
+      }
+      table.sizeToFit()
+      let contentWidth = visible.reduce(CGFloat.zero) {
+        $0 + $1.width + table.intercellSpacing.width
+      }
+      table.setFrameSize(
+        NSSize(width: max(scroll.contentSize.width, contentWidth), height: table.frame.height))
+    }
+    func tableViewColumnDidResize(_ notification: Notification) {
+      guard !adjustingColumns else { return }
+      automaticSizing = false
+      saveSizing()
+    }
     func refresh() {
       let selection = Set(
         table?.selectedRowIndexes.compactMap { rows.indices.contains($0) ? rows[$0].id : nil } ?? []
@@ -160,10 +249,17 @@ struct DiagnosticTable: NSViewRepresentable {
         tableView.makeView(withIdentifier: identifier, owner: self) as? NSTextField
         ?? NSTextField(labelWithString: "")
       field.identifier = identifier
-      field.font = .monospacedDigitSystemFont(ofSize: 12, weight: .regular)
+      let numeric = DiagnosticColumnLayout.numeric(column.title)
+      field.font =
+        numeric
+        ? .monospacedDigitSystemFont(ofSize: 12, weight: .regular)
+        : .systemFont(ofSize: 12)
+      field.alignment = numeric ? .right : .left
       field.textColor = NSColor(theme.text)
-      field.lineBreakMode = .byTruncatingMiddle
-      field.stringValue = rows[row].cells[column.title] ?? "—"
+      field.lineBreakMode =
+        DiagnosticColumnLayout.flexible(column.title) ? .byTruncatingMiddle : .byTruncatingTail
+      let value = rows[row].cells[column.title] ?? ""
+      field.stringValue = value.isEmpty ? "—" : value
       field.toolTip = field.stringValue
       field.setAccessibilityLabel(column.title + ": " + field.stringValue)
       return field
@@ -198,8 +294,13 @@ struct DiagnosticTable: NSViewRepresentable {
       else { return }
       column.isHidden.toggle()
       sender.state = column.isHidden ? .off : .on
+      fitColumns()
     }
     func validateMenuItem(_ item: NSMenuItem) -> Bool {
+      if let column = item.representedObject as? NSTableColumn {
+        item.state = column.isHidden ? .off : .on
+        return column.isHidden || (table?.tableColumns.filter { !$0.isHidden }.count ?? 0) > 1
+      }
       if item.action == #selector(reveal) { return selected.contains { $0.path != nil } }
       if item.action == #selector(copyRows) { return !selected.isEmpty }
       return true
@@ -235,4 +336,55 @@ private final class DiagnosticRowView: NSTableRowView {
     NSRect(x: 0, y: 0, width: 2, height: bounds.height).fill()
   }
   override var interiorBackgroundStyle: NSView.BackgroundStyle { .normal }
+}
+
+/// Column policies keep the initial diagnostic tables readable at the minimum window
+/// width. All source fields remain available for searching, export and customization.
+enum DiagnosticColumnLayout {
+  static func defaults(_ key: String) -> Set<String>? {
+    switch key {
+    case "Threads": return ["Thread ID", "Name", "CPU %", "User time", "State"]
+    case "Open files": return ["FD", "Type", "Path", "Size"]
+    case "Connections": return ["FD", "Protocol", "Local endpoint", "Remote endpoint", "State"]
+    case "Memory map": return ["Address", "Size", "Resident", "Path"]
+    case "Mapped images": return ["Path", "Size", "Resident"]
+    case "Mach ports": return ["Name", "Rights"]
+    case "Fileports": return ["Port name", "Descriptor type"]
+    default: return nil
+    }
+  }
+  static func flexible(_ title: String) -> Bool {
+    ["Path", "Name", "Local endpoint", "Remote endpoint", "Rights"].contains(title)
+  }
+  static func numeric(_ title: String) -> Bool {
+    [
+      "FD", "Thread ID", "CPU %", "User time", "System time", "Size", "Resident",
+      "Private resident", "Shared resident", "Swapped", "Dirty", "Offset", "Inode",
+      "Priority", "Base priority", "Max priority", "Sleep seconds", "References",
+      "Receive queue", "Send queue",
+    ].contains(title)
+  }
+  static func minimum(_ title: String) -> CGFloat {
+    switch title {
+    case "FD": return 30
+    case "CPU %": return 52
+    case "Thread ID": return 72
+    case "Address", "Thread handle": return 140
+    case "Path": return 120
+    case "Local endpoint", "Remote endpoint": return 100
+    case "Name", "Rights": return 90
+    case "Size", "Resident", "User time", "System time": return 72
+    case "Protocol", "Type": return 60
+    case "State": return 78
+    default: return max(65, CGFloat(title.count) * 6 + 16)
+    }
+  }
+}
+
+private final class DiagnosticScrollView: NSScrollView {
+  var fitColumns: (() -> Void)?
+  override func layout() {
+    super.layout()
+    fitColumns?()
+  }
 }

--- a/Tests/ActivityMonitorTests/ProcessDiagnosticsUITests.swift
+++ b/Tests/ActivityMonitorTests/ProcessDiagnosticsUITests.swift
@@ -34,6 +34,8 @@ import XCTest
             "Send queue",
           ]
         case .maps, .images: columns = ["Address", "Size", "Resident", "Protection", "Path"]
+        case .ports: columns = ["Name", "Rights", "Mask"]
+        case .fileports: columns = ["Port name", "Descriptor type"]
         default: columns = ["Name", "Rights", "Type"]
         }
         let records: [DiagnosticRecord] = (0..<2500).map { index in
@@ -106,6 +108,16 @@ import XCTest
           host.layoutSubtreeIfNeeded()
           let bitmap = try XCTUnwrap(host.bitmapImageRepForCachingDisplay(in: host.bounds))
           host.cacheDisplay(in: host.bounds, to: bitmap)
+          if let directory = ProcessInfo.processInfo.environment["AM_RENDER_DIR"],
+            tab == .files || tab == .maps,
+            let png = bitmap.representation(using: .png, properties: [:])
+          {
+            let url = URL(fileURLWithPath: directory).appendingPathComponent(
+              "diagnostic-\(tab.rawValue)-\(dark ? "dark" : "light")-\(Int(size.width)).png")
+            try FileManager.default.createDirectory(
+              at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try png.write(to: url)
+          }
           XCTAssertGreaterThan(bitmap.pixelsWide, 700, "\(tab) \(dark)")
           XCTAssertEqual(host.bounds.width, size.width, accuracy: 1)
           if tab.metric == nil && tab != .overview && tab != .reports {
@@ -117,6 +129,15 @@ import XCTest
             XCTAssertTrue(table.allowsColumnReordering)
             let scroll = try XCTUnwrap(table.enclosingScrollView)
             XCTAssertLessThanOrEqual(scroll.frame.maxX, host.bounds.width + 1)
+            let visible = table.tableColumns.filter { !$0.isHidden }
+            if let expected = DiagnosticColumnLayout.defaults(tab.rawValue) {
+              XCTAssertEqual(
+                Set(visible.map(\.title)),
+                expected.intersection(Set(session.sections[tab]!.columns)))
+            }
+            XCTAssertLessThanOrEqual(
+              table.bounds.width, scroll.contentSize.width + 1,
+              "Default columns overflow in \(tab) at \(size)")
             table.scrollRowToVisible(2499)
             host.layoutSubtreeIfNeeded()
             XCTAssertTrue(table.rows(in: scroll.documentVisibleRect).contains(2499))
@@ -165,6 +186,60 @@ import XCTest
     XCTAssertEqual(table.numberOfRows, 1)
     XCTAssertEqual(table.selectedRow, 0)
   }
+  func testDiagnosticColumnCustomizationAndAdaptiveFit() async throws {
+    let titles = ["FD", "Type", "Path", "Size", "Offset", "Inode", "Access"]
+    let section = DiagnosticSection(
+      columns: titles,
+      records: [
+        DiagnosticRecord(
+          id: "1", cells: ["FD": "42", "Path": "/a/long/path/file.txt", "Size": "512 KB"],
+          numbers: ["FD": 42])
+      ], status: "1 entry", date: Date())
+    let host = NSHostingView(
+      rootView: DiagnosticTable(
+        section: section, query: "", key: "Open files",
+        theme: .init(dark: false), persistColumns: false))
+    let window = NSWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 540, height: 300),
+      styleMask: [.borderless], backing: .buffered, defer: false)
+    window.isReleasedWhenClosed = false
+    window.contentView = host
+    defer {
+      window.contentView = nil
+      window.close()
+    }
+    host.layoutSubtreeIfNeeded()
+    let table = try XCTUnwrap(descendant(host, NSTableView.self))
+    let scroll = try XCTUnwrap(table.enclosingScrollView)
+    let coordinator = try XCTUnwrap(table.delegate as? DiagnosticTable.Coordinator)
+    for width in [540.0, 900.0, 540.0] {
+      window.setContentSize(NSSize(width: width, height: 300))
+      host.layoutSubtreeIfNeeded()
+      coordinator.fitColumns()
+      XCTAssertLessThanOrEqual(table.bounds.width, scroll.contentSize.width + 1)
+      XCTAssertTrue(coordinator.automaticSizing)
+    }
+    let path = try XCTUnwrap(table.tableColumns.first { $0.title == "Path" })
+    path.width = 850
+    XCTAssertFalse(coordinator.automaticSizing)
+    coordinator.fitColumns()
+    XCTAssertEqual(path.width, 850, accuracy: 1)
+    let menu = try XCTUnwrap(table.headerView?.menu)
+    let inodeItem = try XCTUnwrap(menu.items.first { $0.title == "Inode" })
+    coordinator.toggleColumn(inodeItem)
+    XCTAssertFalse((inodeItem.representedObject as! NSTableColumn).isHidden)
+    table.moveColumn(0, toColumn: 2)
+    coordinator.restoreDefaults()
+    XCTAssertEqual(table.tableColumns.map(\.title), titles)
+    XCTAssertEqual(
+      Set(table.tableColumns.filter { !$0.isHidden }.map(\.title)), ["FD", "Type", "Path", "Size"])
+    XCTAssertLessThanOrEqual(table.bounds.width, scroll.contentSize.width + 1)
+    let field = try XCTUnwrap(
+      coordinator.tableView(table, viewFor: table.tableColumns[0], row: 0) as? NSTextField)
+    XCTAssertEqual(field.alignment, .right)
+    XCTAssertEqual(field.toolTip, "42")
+  }
+
   func testAccessDeniedDoesNotClaimExitAndRefreshSwitchesToLatestTab() async throws {
     let row = PerformanceFixture.rows(1)[0]
     let denied = ProcessDiagnosticSession(

--- a/docs/diagnostics/README.md
+++ b/docs/diagnostics/README.md
@@ -17,6 +17,8 @@ The workspace provides:
 - **Mapped images:** executable file mappings. Libraries within the shared dyld cache may not appear individually; a virtual-memory report provides additional context.
 - **Reports:** stack sampling, complete `lsof` output, `vmmap`, launch arguments, environment, code signature, and entitlements. Reports are collected only on request.
 
+Diagnostic tables initially show a compact selection of useful columns and fit the available window width. Right-click any column header to show extra fields, fit the current columns to the window, or restore the defaults. Manually resized columns retain their widths; horizontal scrolling remains available for wider custom layouts. Numeric values align to the right, and hovering reveals complete values and paths. Search and CSV exports include hidden fields.
+
 Tables support column resizing, double-click fitting, drag reordering, sorting, header-menu visibility, multiple selection, keyboard navigation, ⌘C, and Finder reveal for file paths. Column layouts are remembered separately per diagnostic table. Filter and export tables as CSV, save reports as text, or export the collected process snapshot, history and reports as JSON.
 
 ## Memory visualizations

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 cd "$(dirname "$0")/.."
-VERSION="${VERSION:-1.6.0}"
+VERSION="${VERSION:-1.6.1}"
 [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "Expected numeric MAJOR.MINOR.PATCH version" >&2; exit 1; }
 if [[ -n "${NOTARY_PROFILE:-}" && "${SIGNING_IDENTITY:-}" != 'Developer ID Application:'* ]]; then
  echo 'Notarization requires a Developer ID Application signing identity.' >&2

--- a/scripts/verify-package.sh
+++ b/scripts/verify-package.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 cd "$(dirname "$0")/.."
-VERSION="${VERSION:-1.6.0}"
+VERSION="${VERSION:-1.6.1}"
 APP='dist/Activity Monitor.app'
 for ARCH in arm64 x86_64; do
   lipo "$APP/Contents/MacOS/ActivityMonitor" -verify_arch "$ARCH"


### PR DESCRIPTION
Diagnostic tables previously displayed every metadata field at fixed widths, so their default layouts required horizontal scrolling even in typical windows. This change gives all seven tables focused default columns and fits them to the viewport, allocating extra space to paths, names and endpoints.

Header menus retain access to every field and add Fit columns to window and Restore default columns. Existing custom native layouts are preserved; manual resizing opts out of automatic fitting. Numeric cells and headers align right, missing text displays a dash, and complete values remain available in tooltips, filtering and CSV exports.

Validation: 122 Swift tests (7 opt-in performance tests skipped here), 12 Python packaging/performance-gate tests, and live AppKit inspection. Headless UI coverage checks all fifteen diagnostic pages in both themes at 760 × 500 and 1060 × 740, default table widths, custom sizing, reordering, and reset. All 22 release performance and memory gates passed. Universal arm64/x86_64 app, DMG, ZIP, version, signatures and checksums verified locally. GitHub-hosted macOS jobs are queued; native Intel runtime validation was not performed.

Prepares version 1.6.1. Signing credentials are not configured, so distribution remains ad-hoc signed and not notarized.
