### PR TITLE
Keep settings menus open during telemetry updates

### DIFF
--- a/Sources/ActivityMonitor/ContentView.swift
+++ b/Sources/ActivityMonitor/ContentView.swift
@@ -298,34 +298,8 @@ struct ContentView: View {
               Image(systemName: monitor.paused ? "play" : "pause")
             }
             .buttonStyle(MonitorIconButton(theme: theme)).help(monitor.paused ? "Resume" : "Pause")
-            Menu {
-              Button("Export visible processes…") {
-                monitor.export(
-                  visibleProcesses, includeHierarchy: processViewMode == .tree, usage: visibleUsage)
-              }
-              Button("Export JSON snapshot…") {
-                monitor.exportJSON(visibleProcesses, usage: visibleUsage)
-              }
-              Button("Export GPU snapshot & history…") {
-                monitor.exportGPU(visibleProcesses, usage: visibleUsage)
-              }
-              Divider()
-              Picker("Appearance", selection: $appearance) {
-                ForEach(["Light", "Dark", "System"], id: \.self) { Text($0).tag($0) }
-              }
-              Toggle("Show monitor in menu bar", isOn: $showMenuBar)
-              Picker("Update interval", selection: $monitor.interval) {
-                Text("Every second").tag(1.0)
-                Text("Every 2 seconds").tag(2.0)
-                Text("Every 5 seconds").tag(5.0)
-              }
-              Divider()
-              Button("All views & themes") { showGallery = true }
-              Button("Keyboard shortcuts & data notes") { showHelp = true }
-            } label: {
-              Image(systemName: "ellipsis").frame(width: 32, height: 32)
-            }
-            .menuStyle(.borderlessButton).menuIndicator(.hidden).fixedSize().help("More")
+            SettingsMenuButton { settingsMenu(compact: true) }
+              .frame(width: 32, height: 32)
           }.padding(.horizontal, layout.gutter)
           if layout.standard {
             MetricSwitcher(metric: Binding(get: { metric }, set: selectMetric), theme: theme)
@@ -400,31 +374,37 @@ struct ContentView: View {
             appearanceButton("Dark", "moon")
             appearanceButton("System", "desktopcomputer")
           }.padding(3).overlay(RoundedRectangle(cornerRadius: 9).stroke(theme.border, lineWidth: 1))
-          Menu {
-            Toggle("Show monitor in menu bar", isOn: $showMenuBar)
-            Button("Export JSON snapshot…") {
-              monitor.exportJSON(visibleProcesses, usage: visibleUsage)
-            }
-            Button("Export GPU snapshot & history…") {
-              monitor.exportGPU(visibleProcesses, usage: visibleUsage)
-            }
-            Divider()
-            Picker("Update interval", selection: $monitor.interval) {
-              Text("Every second").tag(1.0)
-              Text("Every 2 seconds").tag(2.0)
-              Text("Every 5 seconds").tag(5.0)
-            }
-            Button("Keyboard shortcuts & data notes") { showHelp = true }
-          } label: {
-            Image(systemName: "ellipsis").font(.system(size: 15)).foregroundStyle(theme.secondary)
-              .frame(width: 32, height: 32)
-          }.menuStyle(.borderlessButton).menuIndicator(.hidden).fixedSize()
+          SettingsMenuButton { settingsMenu(compact: false) }
+            .frame(width: 32, height: 32)
         }
       }.padding(.horizontal, 23)
 
     }.frame(height: 78).background(theme.toolbar).overlay(alignment: .bottom) {
       Rectangle().fill(theme.border).frame(height: 1)
     }
+  }
+  private func settingsMenu(compact: Bool) -> NSMenu {
+    let menu = NSMenu()
+    if compact {
+      menu.addSettingsAction("Export visible processes…") {
+        monitor.export(
+          visibleProcesses, includeHierarchy: processViewMode == .tree, usage: visibleUsage)
+      }
+    }
+    menu.addSettingsAction("Export JSON snapshot…") {
+      monitor.exportJSON(visibleProcesses, usage: visibleUsage)
+    }
+    menu.addSettingsAction("Export GPU snapshot & history…") {
+      monitor.exportGPU(visibleProcesses, usage: visibleUsage)
+    }
+    menu.addItem(.separator())
+    if compact { menu.addAppearance($appearance) }
+    menu.addSettingsToggle("Show monitor in menu bar", selection: $showMenuBar)
+    menu.addUpdateInterval($monitor.interval)
+    if compact { menu.addItem(.separator()) }
+    if compact { menu.addSettingsAction("All views & themes") { showGallery = true } }
+    menu.addSettingsAction("Keyboard shortcuts & data notes") { showHelp = true }
+    return menu
   }
   func appearanceButton(_ name: String, _ icon: String) -> some View {
     Button {

--- a/Sources/ActivityMonitor/MenuBarMonitor.swift
+++ b/Sources/ActivityMonitor/MenuBarMonitor.swift
@@ -46,21 +46,17 @@ struct MenuBarMonitor: View {
         }
         .buttonStyle(MonitorIconButton(theme: theme)).help(
           monitor.paused ? "Resume monitoring" : "Pause monitoring")
-        Menu {
-          Picker("Appearance", selection: $appearance) {
-            ForEach(["Light", "Dark", "System"], id: \.self) { Text($0).tag($0) }
-          }
-          Picker("Update interval", selection: $monitor.interval) {
-            Text("Every second").tag(1.0)
-            Text("Every 2 seconds").tag(2.0)
-            Text("Every 5 seconds").tag(5.0)
-          }
-          Divider()
-          Button("Quit Activity Monitor") { NSApp.terminate(nil) }
-        } label: {
-          Image(systemName: "ellipsis").frame(width: 28, height: 28)
+        SettingsMenuButton(
+          size: 28, accessibilityLabel: "Monitor settings", toolTip: "Monitor settings"
+        ) {
+          let menu = NSMenu()
+          menu.addAppearance($appearance)
+          menu.addUpdateInterval($monitor.interval)
+          menu.addItem(.separator())
+          menu.addSettingsAction("Quit Activity Monitor") { NSApp.terminate(nil) }
+          return menu
         }
-        .menuStyle(.borderlessButton).menuIndicator(.hidden).fixedSize().help("Monitor settings")
+        .frame(width: 28, height: 28)
       }.padding(16)
       MetricSwitcher(metric: $presentation.metric, theme: theme, compact: true).padding(
         .horizontal, 14)

--- a/Sources/ActivityMonitor/SettingsMenuButton.swift
+++ b/Sources/ActivityMonitor/SettingsMenuButton.swift
@@ -1,0 +1,150 @@
+import AppKit
+import SwiftUI
+
+/// A settings button whose native menu remains independent from SwiftUI telemetry updates.
+///
+/// SwiftUI's `Menu` is rebuilt when the observed monitor publishes a new process snapshot. If
+/// a nested submenu is open at that moment, AppKit loses the menu tracking session. The button
+/// below is a stable `NSView`; it creates a native menu only when the user opens it and updates
+/// only the factory while the view is being redrawn.
+struct SettingsMenuButton: NSViewRepresentable {
+  var size: CGFloat = 32
+  var accessibilityLabel = "More"
+  var toolTip = "More"
+  var makeMenu: () -> NSMenu
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(makeMenu: makeMenu)
+  }
+
+  func makeNSView(context: Context) -> NSButton {
+    let image =
+      NSImage(
+        systemSymbolName: "ellipsis",
+        accessibilityDescription: accessibilityLabel
+      ) ?? NSImage()
+    image.isTemplate = true
+    let button = NSButton(
+      image: image,
+      target: context.coordinator,
+      action: #selector(Coordinator.openMenu(_:))
+    )
+    button.isBordered = false
+    button.bezelStyle = .regularSquare
+    button.setButtonType(.momentaryPushIn)
+    button.imagePosition = .imageOnly
+    button.imageScaling = .scaleProportionallyDown
+    button.focusRingType = .none
+    button.contentTintColor = .secondaryLabelColor
+    button.toolTip = toolTip
+    button.setAccessibilityLabel(accessibilityLabel)
+    button.setAccessibilityIdentifier("monitor-settings")
+    return button
+  }
+
+  func updateNSView(_ button: NSButton, context: Context) {
+    // Keep the native button and any menu AppKit is tracking. Only the next-open factory changes.
+    context.coordinator.makeMenu = makeMenu
+    button.toolTip = toolTip
+    button.setAccessibilityLabel(accessibilityLabel)
+  }
+
+  func sizeThatFits(
+    _ proposal: ProposedViewSize, nsView: NSButton, context: Context
+  ) -> CGSize? {
+    CGSize(width: size, height: size)
+  }
+
+  final class Coordinator: NSObject, NSMenuDelegate {
+    var makeMenu: () -> NSMenu
+    private var activeMenu: NSMenu?
+
+    init(makeMenu: @escaping () -> NSMenu) {
+      self.makeMenu = makeMenu
+    }
+
+    @objc func openMenu(_ sender: NSButton) {
+      let menu = makeMenu()
+      activeMenu = menu
+      menu.delegate = self
+      // NSMenu positions a popup from the supplied point in the sender's coordinate space. The
+      // lower edge is the correct anchor for an unflipped title-bar view; use the upper edge for
+      // a flipped host such as a popover.
+      let point =
+        sender.isFlipped
+        ? NSPoint(x: sender.bounds.minX, y: sender.bounds.maxY + 4)
+        : NSPoint(x: sender.bounds.minX, y: sender.bounds.minY - 4)
+      menu.popUp(positioning: nil, at: point, in: sender)
+      if activeMenu === menu { activeMenu = nil }
+    }
+
+    func menuDidClose(_ menu: NSMenu) {
+      if activeMenu === menu { activeMenu = nil }
+    }
+  }
+}
+
+private final class SettingsMenuItem: NSMenuItem {
+  private let handler: () -> Void
+
+  init(_ title: String, checked: Bool = false, action: @escaping () -> Void) {
+    handler = action
+    super.init(title: title, action: #selector(invoke), keyEquivalent: "")
+    target = self
+    state = checked ? .on : .off
+  }
+
+  required init(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  @objc private func invoke() {
+    handler()
+  }
+}
+
+extension NSMenu {
+  func addSettingsAction(
+    _ title: String, checked: Bool = false, action: @escaping () -> Void
+  ) {
+    addItem(SettingsMenuItem(title, checked: checked, action: action))
+  }
+
+  func addSettingsChoices<Value: Equatable>(
+    _ title: String, values: [(String, Value)], selection: Binding<Value>
+  ) {
+    let submenu = NSMenu(title: title)
+    for (label, value) in values {
+      submenu.addSettingsAction(label, checked: selection.wrappedValue == value) {
+        selection.wrappedValue = value
+      }
+    }
+    let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+    item.submenu = submenu
+    addItem(item)
+  }
+
+  func addSettingsToggle(
+    _ title: String, selection: Binding<Bool>
+  ) {
+    addSettingsAction(title, checked: selection.wrappedValue) {
+      selection.wrappedValue.toggle()
+    }
+  }
+
+  func addUpdateInterval(_ selection: Binding<Double>) {
+    addSettingsChoices(
+      "Update interval",
+      values: [("Every second", 1.0), ("Every 2 seconds", 2.0), ("Every 5 seconds", 5.0)],
+      selection: selection
+    )
+  }
+
+  func addAppearance(_ selection: Binding<String>) {
+    addSettingsChoices(
+      "Appearance",
+      values: ["Light", "Dark", "System"].map { ($0, $0) },
+      selection: selection
+    )
+  }
+}

--- a/Tests/ActivityMonitorTests/MenuInteractionTests.swift
+++ b/Tests/ActivityMonitorTests/MenuInteractionTests.swift
@@ -1,0 +1,92 @@
+import AppKit
+import SwiftUI
+import XCTest
+
+@testable import ActivityMonitor
+
+private struct UpdatingSettingsHarness: View {
+  @ObservedObject var monitor: Monitor
+
+  var body: some View {
+    VStack {
+      Text("Rows: \(monitor.rows.count) · CPU: \(monitor.userCPU)")
+      SettingsMenuButton {
+        let menu = NSMenu()
+        menu.addUpdateInterval($monitor.interval)
+        return menu
+      }
+    }
+  }
+}
+
+@MainActor final class MenuInteractionTests: XCTestCase {
+  func testSettingsButtonSurvivesTelemetryRefreshesAndKeepsMenuSourceStable() async throws {
+    _ = NSApplication.shared
+    let monitor = Monitor(startAutomatically: false)
+    let host = NSHostingView(rootView: UpdatingSettingsHarness(monitor: monitor))
+    let window = testWindow()
+    window.contentView = host
+    defer {
+      window.contentView = nil
+      window.close()
+    }
+    host.layoutSubtreeIfNeeded()
+    try await Task.sleep(for: .milliseconds(25))
+
+    let button = try XCTUnwrap(findButton(in: host))
+    let coordinator = try XCTUnwrap(button.target as? SettingsMenuButton.Coordinator)
+    let menu = coordinator.makeMenu()
+    let submenu = try XCTUnwrap(menu.items.first?.submenu)
+    XCTAssertEqual(submenu.items[0].state, .on)
+
+    for value in 1...5 {
+      monitor.rows = []
+      monitor.userCPU = Double(value)
+      monitor.lastUpdate = Date(timeIntervalSince1970: Double(value))
+      host.layoutSubtreeIfNeeded()
+      XCTAssertTrue(findButton(in: host) === button)
+      XCTAssertTrue(button.target === coordinator)
+      XCTAssertTrue(menu.items.first?.submenu === submenu)
+    }
+
+    let twoSeconds = submenu.items[1]
+    XCTAssertTrue(
+      NSApp.sendAction(try XCTUnwrap(twoSeconds.action), to: twoSeconds.target, from: twoSeconds))
+    XCTAssertEqual(monitor.interval, 2)
+    let reopened = try XCTUnwrap(coordinator.makeMenu().items.first?.submenu)
+    XCTAssertEqual(reopened.items[0].state, .off)
+    XCTAssertEqual(reopened.items[1].state, .on)
+  }
+
+  func testSettingsMenuButtonExposesAccessibleNativeControl() throws {
+    _ = NSApplication.shared
+    let host = NSHostingView(
+      rootView: SettingsMenuButton(accessibilityLabel: "Monitor settings") { NSMenu() }
+    )
+    let window = testWindow()
+    window.contentView = host
+    defer {
+      window.contentView = nil
+      window.close()
+    }
+    host.layoutSubtreeIfNeeded()
+
+    let button = try XCTUnwrap(findButton(in: host))
+    XCTAssertEqual(button.accessibilityLabel(), "Monitor settings")
+    XCTAssertEqual(button.accessibilityIdentifier(), "monitor-settings")
+    XCTAssertFalse(button.isBordered)
+  }
+
+  private func findButton(in view: NSView) -> NSButton? {
+    if let button = view as? NSButton { return button }
+    return view.subviews.lazy.compactMap { self.findButton(in: $0) }.first
+  }
+
+  private func testWindow() -> NSWindow {
+    let window = NSWindow(
+      contentRect: NSRect(x: 0, y: 0, width: 180, height: 120),
+      styleMask: .borderless, backing: .buffered, defer: false)
+    window.isReleasedWhenClosed = false
+    return window
+  }
+}


### PR DESCRIPTION
Fixes #19

The settings menu was implemented as a SwiftUI `Menu` inside the view that observes live process rows. Every telemetry publication rebuilt that menu, which ended AppKit's tracking session and closed the nested Update interval submenu before a short interval could be selected.

This change gives the settings control a stable AppKit host:

- `SettingsMenuButton` keeps one native `NSButton` and coordinator while SwiftUI redraws the dashboard.
- A native `NSMenu` is created when opened and retained for the duration of menu tracking; redraws update only the factory used by the next opening.
- The standard title bar, compact title bar, and menu bar popover share the same native settings-menu actions and interval/appearance choices.
- The native button keeps an accessible label and identifier.
- Regression tests verify the button and coordinator survive repeated published telemetry updates, interval actions update `Monitor.interval`, and accessibility metadata remains available.

Validation:

- Full local suite: 154 tests, 7 opt-in performance tests skipped, 0 failures.
- Release performance gates pass on an idle desktop, including table refresh/scroll and memory growth.
- Universal arm64 + x86_64 app, DMG, ZIP, signatures, versions, and checksums verify locally.
- Native verification keeps the Update interval submenu open across multiple live telemetry ticks and applies the two-second option.
