### PR TITLE
Compact process tree column menu summary

### DIFF
--- a/Sources/ActivityMonitor/ProcessSubtreeUsage.swift
+++ b/Sources/ActivityMonitor/ProcessSubtreeUsage.swift
@@ -132,6 +132,9 @@ struct ProcessSubtreeUsage: Equatable {
   static let scopeHelp =
     "Σ includes the process and all current descendants, even when hidden by search or collapse. ≥ marks a partial subtotal; — means no available counters. Parent and child totals overlap."
 
+  /// Short enough to keep the column menu compact while retaining its accounting warning.
+  static let menuScopeHelp = "Σ includes descendants; ≥ means partial; totals overlap."
+
   var description: String {
     "Subtree: \(processCount) \(processCount == 1 ? "process" : "processes"), including this process. "
       + Self.scopeHelp

--- a/Sources/ActivityMonitor/ProcessSubtreeUsage.swift
+++ b/Sources/ActivityMonitor/ProcessSubtreeUsage.swift
@@ -133,7 +133,7 @@ struct ProcessSubtreeUsage: Equatable {
     "Σ includes the process and all current descendants, even when hidden by search or collapse. ≥ marks a partial subtotal; — means no available counters. Parent and child totals overlap."
 
   /// Short enough to keep the column menu compact while retaining its accounting warning.
-  static let menuScopeHelp = "Σ includes descendants; ≥ means partial; totals overlap."
+  static let menuScopeHelp = "Σ descendants; ≥ partial; totals overlap."
 
   var description: String {
     "Subtree: \(processCount) \(processCount == 1 ? "process" : "processes"), including this process. "

--- a/Sources/ActivityMonitor/ProcessTable.swift
+++ b/Sources/ActivityMonitor/ProcessTable.swift
@@ -389,7 +389,7 @@ struct MonitorProcessTable: View {
       descending = true
     }
     Text("— means the metric is unavailable.")
-    if hierarchy { Text(ProcessSubtreeUsage.scopeHelp) }
+    if hierarchy { Text(ProcessSubtreeUsage.menuScopeHelp) }
   }
   var compactToolbar: some View {
     VStack(spacing: 8) {


### PR DESCRIPTION
## Problem

The process tree column menu used the full subtree accounting explanation as a menu item, so AppKit sized the native menu to the entire sentence and made it unnecessarily wide.

## Change

- Add a compact menu-specific summary for subtree totals.
- Keep the full accounting explanation for tooltips, accessibility text, and exports.

## Validation

- `swift test` — 154 tests passed, 7 performance tests skipped.
